### PR TITLE
Add semver and version increase check

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -32,6 +32,7 @@ version = "0.0.2"
 dependencies = [
  "anyhow",
  "cargo_metadata",
+ "semver",
  "toml_edit",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,3 +16,4 @@ keywords = ["cargo", "dependencies"]
 toml_edit = "0.22.26"
 cargo_metadata = "0.19.2"
 anyhow = "1.0.98"
+semver = "1.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,20 @@
+use anyhow::{Result, anyhow};
+use semver::Version;
+
+pub fn parse_new_version(input: &str) -> Result<Version> {
+    Version::parse(input)
+        .map_err(|err| anyhow!("'{}' is not a valid semver version: {}", input, err))
+}
+
+pub fn ensure_version_increase(new: &Version, current: &Version, package_name: &str) -> Result<()> {
+    if new <= current {
+        Err(anyhow!(
+            "new version '{}' must be greater than current version '{}' for package '{}'",
+            new,
+            current,
+            package_name,
+        ))
+    } else {
+        Ok(())
+    }
+}

--- a/tests/lib_tests.rs
+++ b/tests/lib_tests.rs
@@ -1,0 +1,40 @@
+use cargo_set_version::{ensure_version_increase, parse_new_version};
+use semver::Version;
+
+#[test]
+fn parse_new_version_rejects_invalid_input() {
+    let err = parse_new_version("bad!!").unwrap_err();
+    assert!(
+        err.to_string()
+            .contains("'bad!!' is not a valid semver version")
+    );
+}
+
+#[test]
+fn bigger_version_allows_update() {
+    let new_version = Version::new(2, 0, 0);
+    let current = Version::new(1, 5, 0);
+    ensure_version_increase(&new_version, &current, "crate").unwrap();
+}
+
+#[test]
+fn smaller_version_rejected() {
+    let new_version = Version::new(1, 0, 0);
+    let current = Version::new(1, 5, 0);
+    let err = ensure_version_increase(&new_version, &current, "crate").unwrap_err();
+    assert!(
+        err.to_string()
+            .contains("new version '1.0.0' must be greater than current version '1.5.0'")
+    );
+}
+
+#[test]
+fn equal_version_rejected() {
+    let new_version = Version::new(1, 5, 0);
+    let current = Version::new(1, 5, 0);
+    let err = ensure_version_increase(&new_version, &current, "crate").unwrap_err();
+    assert!(
+        err.to_string()
+            .contains("new version '1.5.0' must be greater than current version '1.5.0'")
+    );
+}


### PR DESCRIPTION
The semantic version is parsed with the `semver` crate, solves the #3 issue. I also got a courage to add the check that ensure that the new version is bigger than the old version, although there was no issue raised for it.

> Note: Added simple test cases, mainly for the error messages. Little overkill, however, it would be benefical to refactor some of the main logic into the `lib.rs` and then create unit tests for them.